### PR TITLE
update instruction formats to V type, O type, and M type

### DIFF
--- a/pif_ir/bir/objects/basic_block.py
+++ b/pif_ir/bir/objects/basic_block.py
@@ -143,13 +143,14 @@ class BasicBlock(object):
 
         # TODO: to ensure correctness, the data_in should be a copy of the 
         #       metadata instance.
-        data_in = instruction[2][0]
+        data_out = instruction[2][0]
+        if data_out:
+            data_out = packet.metadata[data_out]
+
+        data_in = instruction[2][1]
         if data_in:
             data_in = packet.metadata[data_in]
 
-        data_out = instruction[2][1]
-        if data_out:
-            data_out = packet.metadata[data_out]
         module(data_in, data_out)
 
     def process(self, packet, bit_offset=0):

--- a/pif_ir/bir/objects/other_module/checksum.py
+++ b/pif_ir/bir/objects/other_module/checksum.py
@@ -1,11 +1,11 @@
 
-def ipv4(ipv4_header):
-    ipv4_header.set_value("chksum", 0)
+def ipv4(ipv4_header_in, ipv4_header_out):
+    ipv4_header_in.set_value("chksum", 0)
 
     shift = False
     tot = 0
     tmp = 0
-    for b in ipv4_header.serialize():
+    for b in ipv4_header_in.serialize():
         if shift:
             tmp = (tmp << 8) + b
             tot += tmp
@@ -19,4 +19,4 @@ def ipv4(ipv4_header):
         lhs = tot >> 16
         tot = lhs + rhs
 
-    ipv4_header.set_value("chksum", ~tot)
+    ipv4_header_out.set_value("chksum", ~tot)

--- a/pif_ir/bir/objects/other_module/checksum.py
+++ b/pif_ir/bir/objects/other_module/checksum.py
@@ -1,5 +1,5 @@
 
-def ipv4(ipv4_header_in, ipv4_header_out):
+def ipv4(ipv4_header_out, ipv4_header_in):
     ipv4_header_in.set_value("chksum", 0)
 
     shift = False

--- a/pif_ir/bir/tests/bir_mpls.yml
+++ b/pif_ir/bir/tests/bir_mpls.yml
@@ -87,7 +87,7 @@ bb_mpls:
     local_table:    mpls_value_set
     instructions:
         - [V, mpls_value_set_req.label, label]
-        - [S, mpls_value_set_resp, mpls_value_set_req]
+        - [O, tLookup, [mpls_value_set_resp, mpls_value_set_req]]
     next_control_state:
         - $offset$ + 32
         - [mpls_value_set_resp.hit == 1, bb_ipv4]

--- a/pif_ir/bir/tests/bir_sample.yml
+++ b/pif_ir/bir/tests/bir_sample.yml
@@ -1,5 +1,5 @@
 # ----- ----- ----- ----- ----- ----- ----- -----
-# Struct Formats
+# Structs
 # ----- ----- ----- ----- ----- ----- ----- -----
 ethernet_t:
     type: struct
@@ -131,7 +131,7 @@ bb_table_udp:
     type:           basic_block
     local_table:    table_0
     instructions:
-        - [S, table_0_resp, table_0_req]
+        - [O, tLookup, [table_0_resp, table_0_req]]
     next_control_state:
         - $offset$
         - [table_0_resp.hit == 1 && table_0_resp.p4_action == 1, bb_action_0]
@@ -199,7 +199,7 @@ deparser:
         - deparse_eth
 
 # ----- ----- ----- ----- ----- ----- ----- -----
-# Layout
+# System
 # ----- ----- ----- ----- ----- ----- ----- -----
 a_p4_switch:
     type:       processor_layout

--- a/pif_ir/bir/tests/test_instance_mpls.py
+++ b/pif_ir/bir/tests/test_instance_mpls.py
@@ -5,7 +5,7 @@ import struct
 import sys
 
 from pif_ir.bir.instance import BirInstance
-from pif_ir.bir.objects.bir_exception import BIRError
+from pif_ir.bir.utils.exceptions import BIRError
 
 logging.basicConfig(level=logging.INFO)
 logging.info("RUNNING TEST: %s" % __file__)

--- a/pif_ir/examples/bir/Makefile
+++ b/pif_ir/examples/bir/Makefile
@@ -8,9 +8,6 @@ PYPATH=PYTHONPATH=${ROOT_DIR}/:${OFTEST_PYTHON}
 sample: submodule
 	sudo ${PYPATH} ./start.py bir_sample.yml
 
-mpls: submodule
-	sudo ${PYPATH} ./start.py bir_mpls.yml
-
 %.yml: submodule
 	sudo ${PYPATH} ./start.py $@
 

--- a/pif_ir/examples/bir/bir_mpls.yml
+++ b/pif_ir/examples/bir/bir_mpls.yml
@@ -86,7 +86,7 @@ bb_mpls:
     local_table:    mpls_value_set
     instructions:
         - [V, mpls_value_set_req.label, label]
-        - [S, mpls_value_set_resp, mpls_value_set_req]
+        - [O, tLookup, [mpls_value_set_resp, mpls_value_set_req]]
     next_control_state:
         - $offset$ + 32
         - [mpls_value_set_resp.hit == 1, bb_ipv4]

--- a/pif_ir/examples/bir/bir_other_module.yml
+++ b/pif_ir/examples/bir/bir_other_module.yml
@@ -1,0 +1,138 @@
+# ----- ----- ----- ----- ----- ----- ----- -----
+# Other Modules
+# ----- ----- ----- ----- ----- ----- ----- -----
+checksum:
+    type:       other_module
+    operations: 
+        - ipv4
+
+# ----- ----- ----- ----- ----- ----- ----- -----
+# Struct Formats
+# ----- ----- ----- ----- ----- ----- ----- -----
+ethernet_t:
+    type: struct
+    fields:
+        - dst:      48
+        - src:      48
+        - type_:    16
+
+ipv4_t:
+    type: struct
+    fields:
+        - version:  4
+        - ihl:      4
+        - tos:      8
+        - len:      16
+        - id:       16
+        - flags:    3
+        - frag:     13
+        - ttl:      8
+        - proto:    8
+        - chksum:   16
+        - src:      32
+        - dst:      32
+
+table_0_req_t:
+    type: struct
+    fields:
+        - dport:        16
+
+table_0_resp_t:
+    type : struct
+    fields:
+        - hit:              1
+        - p4_action:        2
+        - action_0_arg0:    16
+        - action_1_arg0:    16
+
+# ----- ----- ----- ----- ----- ----- ----- -----
+# Metadata Instances
+# ----- ----- ----- ----- ----- ----- ----- -----
+eth:
+    type:       metadata
+    values:     ethernet_t
+    visibility: none
+
+ipv4:
+    type:       metadata
+    values:     ipv4_t
+    visibility: none
+
+
+# ----- ----- ----- ----- ----- ----- ----- -----
+# Parser
+# ----- ----- ----- ----- ----- ----- ----- -----
+parse_eth:
+    type:           basic_block
+    local_header:   ethernet_t
+    instructions:
+        - [V, eth.type_, type_]
+    next_control_state:
+        - $offset$ + 112
+        - [type_ == 0x0800, parse_ipv4]
+        - $done$
+
+parse_ipv4:
+    type:           basic_block
+    local_header:   ipv4_t
+    instructions:
+        - [V, ipv4.version, version]
+        - [V, ipv4.ihl, ihl]
+        - [V, ipv4.tos, tos]
+        - [V, ipv4.len, len]
+        - [V, ipv4.id, id]
+        - [V, ipv4.flags, flags]
+        - [V, ipv4.frag, frag]
+        - [V, ipv4.ttl, ttl - 1]
+        - [V, ipv4.proto, proto]
+        - [V, ipv4.chksum, chksum]
+        - [V, ipv4.src, src]
+        - [V, ipv4.dst, dst]
+        - [M, checksum.ipv4, [ipv4]]
+    next_control_state:
+        - $offset$ + 160
+        - $done$
+
+parser:
+    type: control_flow
+    start_control_state: 
+        - 0
+        - parse_eth
+
+# ----- ----- ----- ----- ----- ----- ----- -----
+# Deparser
+# ----- ----- ----- ----- ----- ----- ----- -----
+deparse_eth:
+    type:           basic_block
+    local_header:   ethernet_t
+    instructions:   []
+    next_control_state:
+        - $offset$ + 112
+        - [eth.type_ == 0x0800, deparse_ipv4]
+        - $done$
+
+deparse_ipv4:
+    type:           basic_block
+    local_header:   ipv4_t
+    instructions:
+        - [V, ttl, ipv4.ttl]
+        - [V, chksum, ipv4.chksum]
+    next_control_state:
+        - $offset$ + 160
+        - $done$
+
+deparser:
+    type: control_flow
+    start_control_state: 
+        - 0
+        - deparse_eth
+
+# ----- ----- ----- ----- ----- ----- ----- -----
+# Layout
+# ----- ----- ----- ----- ----- ----- ----- -----
+a_p4_switch:
+    type:       processor_layout
+    format:     list
+    implementation:
+        - parser
+        - deparser

--- a/pif_ir/examples/bir/bir_other_module.yml
+++ b/pif_ir/examples/bir/bir_other_module.yml
@@ -88,7 +88,7 @@ parse_ipv4:
         - [V, ipv4.chksum, chksum]
         - [V, ipv4.src, src]
         - [V, ipv4.dst, dst]
-        - [M, checksum.ipv4, [ipv4]]
+        - [M, checksum.ipv4, [ipv4, ipv4]]
     next_control_state:
         - $offset$ + 160
         - $done$

--- a/pif_ir/examples/bir/bir_sample.yml
+++ b/pif_ir/examples/bir/bir_sample.yml
@@ -1,5 +1,5 @@
 # ----- ----- ----- ----- ----- ----- ----- -----
-# Struct Formats
+# Structs
 # ----- ----- ----- ----- ----- ----- ----- -----
 ethernet_t:
     type: struct
@@ -131,7 +131,7 @@ bb_table_udp:
     type:           basic_block
     local_table:    table_0
     instructions:
-        - [S, table_0_resp, table_0_req]
+        - [O, tLookup, [table_0_resp, table_0_req]]
     next_control_state:
         - $offset$
         - [table_0_resp.hit == 1 && table_0_resp.p4_action == 1, bb_action_0]
@@ -199,7 +199,7 @@ deparser:
         - deparse_eth
 
 # ----- ----- ----- ----- ----- ----- ----- -----
-# Layout
+# System
 # ----- ----- ----- ----- ----- ----- ----- -----
 a_p4_switch:
     type:       processor_layout


### PR DESCRIPTION
new instruction formats:
[V, _dest, src_]
[O, _operand_, [_argument list_]]
[M, _method_, [_metadata out_, _metadata in_]]  

In the M type instruction the YAML keyword null is used for metadata in, or metadata out if the argument is not needed 
